### PR TITLE
fix: misalignment between tab and panel in `calendar-tab`

### DIFF
--- a/src/components/calendar-tab/index.tsx
+++ b/src/components/calendar-tab/index.tsx
@@ -29,22 +29,18 @@ export default function CalendarTab({
     unknown: '未知',
   };
 
-  const keys = Object.keys(engToZh);
-
   // eslint-disable-next-line @fluffyfox/no-unsafe-date -- ignore
   const date = new Date().getDay();
-  const toDay = date !== 0 ? date - 1 : 6;
+  const toDay = date;
 
   return (
     <Tabs position="relative" isLazy lazyBehavior="keepMounted" {...props} defaultIndex={toDay}>
       <TabList top="4px" borderBottom="none" pb="2px" minH="42px" {...tabListProps}>
-        {tabListItems
-          .sort((a, b) => (keys.indexOf(a) > keys.indexOf(b) ? 1 : -1))
-          .map(week => (
-            <Tab whiteSpace="nowrap" mb="-2px" key={week}>
-              {engToZh[week]}
-            </Tab>
-          ))}
+        {tabListItems.map(week => (
+          <Tab whiteSpace="nowrap" mb="-2px" key={week}>
+            {engToZh[week]}
+          </Tab>
+        ))}
       </TabList>
       <Box top="46.5px" borderBottom="2px solid" mt="-2.5px" borderBottomColor="inherit" {...boxProps} />
 

--- a/src/components/calendar-tab/index.tsx
+++ b/src/components/calendar-tab/index.tsx
@@ -30,8 +30,7 @@ export default function CalendarTab({
   };
 
   // eslint-disable-next-line @fluffyfox/no-unsafe-date -- ignore
-  const date = new Date().getDay();
-  const toDay = date;
+  const toDay = new Date().getDay();
 
   return (
     <Tabs position="relative" isLazy lazyBehavior="keepMounted" {...props} defaultIndex={toDay}>


### PR DESCRIPTION
之前把 tab 改成中文的时候把 tab 排序了，但是没给 panel 排序
导致对应的内容错位了，用了这么久才发现。b38